### PR TITLE
feat: add automatic invoicing

### DIFF
--- a/classes/gateway.php
+++ b/classes/gateway.php
@@ -118,6 +118,9 @@ class gateway extends \core_payment\gateway {
         ]);
         $mform->addHelpButton('defaulttaxbehavior', 'defaulttaxbehavior', 'paygw_stripe');
 
+        $mform->addElement('advcheckbox', 'automaticinvoices', get_string('automaticinvoices', 'paygw_stripe'));
+        $mform->setDefault('automaticinvoices', true);
+
         $mform->addElement('select', 'type', get_string('paymenttype', 'paygw_stripe'), [
             'onetime' => get_string('paymenttype:onetime', 'paygw_stripe'),
             'subscription' => get_string('paymenttype:subscription', 'paygw_stripe'),

--- a/classes/stripe_helper.php
+++ b/classes/stripe_helper.php
@@ -337,7 +337,18 @@ class stripe_helper {
             'automatic_tax' => [
                 'enabled' => $config->enableautomatictax == 1,
             ],
+            'billing_address_collection' => $config->automaticinvoicing == 1 ? "required" : "auto",
             'customer' => $customer->id,
+            'invoice_creation' => [
+                'enabled' => $config->automaticinvoicing == 1,
+                'invoice_data' => [
+                    'issuer' => [ 
+                        'type' => "self",
+                    ],
+                    'description' => $description,
+                    'rendering_options' => "include_inclusive_tax",
+                ],
+            ],
             'metadata' => [
                 'userid' => $USER->id,
                 'username' => $USER->username,

--- a/lang/en/paygw_stripe.php
+++ b/lang/en/paygw_stripe.php
@@ -70,6 +70,7 @@ $string['updatepaymentmethod'] = 'Update Payment Method';
 $string['cancel'] = 'Cancel';
 $string['subscriptionssubheading'] =
     'This page lists the subscriptions you have purchased. You can cancel subscriptions here, cancellations will be processed immediately and you will not be able to enter the course again.';
+$string['automaticinvoices'] = 'Enable automatic invoicing';
 
 $string['customsubscriptioninterval:day'] = 'Day';
 $string['customsubscriptioninterval:week'] = 'Week';


### PR DESCRIPTION
## Description

This PR adds the option of creating automated invoices when selling a course. I had to implement this at work, so I thought I might as well contribute to this plugin!

Regarding the `invoice_creation.invoice_data` field: There has to be some information saved for the creation to work, but if the invoice creation is not enabled, nothing happens.

Closes #21 