### PR TITLE
Add "Affirm" option to payment methods list.

### DIFF
--- a/classes/gateway.php
+++ b/classes/gateway.php
@@ -88,6 +88,7 @@ class gateway extends \core_payment\gateway {
 
         $paymentmethods = [
             'card' => get_string('paymentmethod:card', 'paygw_stripe'),
+            'affirm' => get_string('paymentmethod:affirm', 'paygw_stripe'),
             'alipay' => get_string('paymentmethod:alipay', 'paygw_stripe'),
             'bancontact' => get_string('paymentmethod:bancontact', 'paygw_stripe'),
             'eps' => get_string('paymentmethod:eps', 'paygw_stripe'),

--- a/lang/en/paygw_stripe.php
+++ b/lang/en/paygw_stripe.php
@@ -117,6 +117,7 @@ $string['paymentmethod:upi'] = 'UPI';
 $string['paymentmethod:netbanking'] = 'NetBanking';
 $string['paymentmethod:wechat_pay'] = 'WeChat Pay';
 $string['paymentmethod:klarna'] = 'Klarna';
+$string['paymentmethod:affirm'] = 'Affirm';
 
 $string['privacy:metadata:stripe_customers'] = 'Stores the relation from Moodle users to Stripe customer objects';
 $string['privacy:metadata:stripe_customers:userid'] = 'Moodle user ID';


### PR DESCRIPTION
The Affirm payment method already exists on the Stripe sdk.
This 2 lines will add the "Affirm" option to the setup page > payment methods list, and enable on the checkout page (previously enbaled on the user stripe dashboard)


![affirm option on stripe plugin](https://github.com/user-attachments/assets/ee8d4f3c-04f3-41bb-9663-800389c526be)

