### PR TITLE
Use stripe Checkout session in subscription mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.1' ]
-        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'master' ]
+        moodle-branch: [ 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE', 'main' ]
         database: [ pgsql, mariadb ]
 
     steps:

--- a/classes/stripe_helper.php
+++ b/classes/stripe_helper.php
@@ -377,7 +377,6 @@ class stripe_helper {
      * @param string $component
      * @param string $paymentarea
      * @param string $itemid
-     * @param string|null $sessionid
      * @return string|null
      * @throws ApiErrorException
      * @throws \coding_exception
@@ -385,7 +384,7 @@ class stripe_helper {
      * @throws \moodle_exception
      */
     public function generate_subscription(object $config, payable $payable, string $description, float $cost, string $component,
-        string $paymentarea, string $itemid, string $sessionid = null): ?string {
+        string $paymentarea, string $itemid): ?string {
         global $CFG, $USER, $DB;
 
         // Ensure webhook exists before we use it.
@@ -400,106 +399,63 @@ class stripe_helper {
             $customer = $this->create_customer($USER);
         }
 
-        if ($sessionid != null) {
-            $session = $this->stripe->checkout->sessions->retrieve($sessionid, ['expand' => ['setup_intent']]);
-            if ($session->status != 'complete') {
-                redirect(new moodle_url('/'), get_string('failedtosetdefaultpaymentmethod', 'paygw_stripe'));
-            } else {
-                $customer = $this->stripe->customers->update($customer->id, ['invoice_settings' =>
-                    ['default_payment_method' => $session->setup_intent->payment_method]]);
-            }
-        }
-
-        if ($customer->invoice_settings->toArray()['default_payment_method'] == null && $sessionid == null) {
-            // Create checkout session to set up default payment source for customer.
-            $session = $this->stripe->checkout->sessions->create([
-                'success_url' => $CFG->wwwroot . '/payment/gateway/stripe/pay.php?component=' . $component . '&paymentarea=' .
-                    $paymentarea . '&itemid=' . $itemid . '&description=' . urlencode($description) .
-                    '&session_id={CHECKOUT_SESSION_ID}',
-                'cancel_url' => $CFG->wwwroot . '/payment/gateway/stripe/cancelled.php?component=' . $component . '&paymentarea=' .
-                    $paymentarea . '&itemid=' . $itemid,
-                'payment_method_types' => $config->paymentmethods,
-                'mode' => 'setup',
-                'automatic_tax' => [
-                    'enabled' => $config->enableautomatictax == 1,
-                ],
-                'customer' => $customer->id,
-                'metadata' => [
-                    'userid' => $USER->id,
-                    'username' => $USER->username,
-                    'firstname' => $USER->firstname,
-                    'lastname' => $USER->lastname,
-                    'component' => $component,
-                    'paymentarea' => $paymentarea,
-                    'itemid' => $itemid,
-                ],
-                'customer_update' => [
-                    'address' => 'auto',
-                ],
-            ]);
-            return $session->id;
-        }
-
-        $subscriptiondata = [
-            'customer' => $customer->id,
-            'items' => [[
-                'price' => $price,
-                'quantity' => 1,
-            ]],
-            'automatic_tax' => [
-                'enabled' => $config->enableautomatictax == 1,
-            ],
-            'payment_settings' => [
-                'payment_method_types' => $config->paymentmethods,
-            ],
-            'collection_method' => 'charge_automatically',
-            'metadata' => [
-                'userid' => $USER->id,
-                'component' => $component,
-                'paymentarea' => $paymentarea,
-                'itemid' => $itemid,
-            ],
-        ];
-
+        // If anchored billing and/or trial period are enabled, set up the subscriptiondata parameter.
+        $subscriptiondata = [];
         if ($config->anchorbilling) {
-            list ($date, $nextdate) = $this->get_anchor_billing_dates($config);
-
-            $subscriptiondata['backdate_start_date'] = $date->getTimestamp();
-            $subscriptiondata['billing_cycle_anchor'] = $nextdate->getTimestamp();
-
+            $subscriptiondata['billing_cycle_anchor'] = $this->get_anchor_billing_dates($config)->getTimestamp();
             if ($config->firstintervalfree) {
-                $subscriptiondata['trial_end'] = $nextdate->getTimestamp();
+                $subscriptiondata['proration_behavior'] = 'none';
             }
         }
         if ($config->firstintervalfree && !$config->anchorbilling) {
             $subscriptiondata['trial_end'] = $this->get_trial_end_date($config)->getTimestamp();
         }
 
-        $subscription = $this->stripe->subscriptions->create($subscriptiondata);
+        // Create checkout session to set up subscription for customer.
+        $session = $this->stripe->checkout->sessions->create([
+            'success_url' => $CFG->wwwroot . '/payment/gateway/stripe/process.php?component=' . $component . '&paymentarea=' .
+                $paymentarea . '&itemid=' . $itemid . '&session_id={CHECKOUT_SESSION_ID}',
+            'cancel_url' => $CFG->wwwroot . '/payment/gateway/stripe/cancelled.php?component=' . $component . '&paymentarea=' .
+                $paymentarea . '&itemid=' . $itemid,
+            'payment_method_types' => $config->paymentmethods,
+            'mode' => 'subscription',
+            'line_items' => [[
+                'price' => $price,
+                'quantity' => 1,
+            ]],
+            'automatic_tax' => [
+                'enabled' => $config->enableautomatictax == 1,
+            ],
+            'allow_promotion_codes' => $config->allowpromotioncodes == 1,
+            'subscription_data' => $subscriptiondata,
+            'customer' => $customer->id,
+            'metadata' => [
+                'userid' => $USER->id,
+                'username' => $USER->username,
+                'firstname' => $USER->firstname,
+                'lastname' => $USER->lastname,
+                'component' => $component,
+                'paymentarea' => $paymentarea,
+                'itemid' => $itemid,
+            ],
+            'customer_update' => [
+                'address' => 'auto',
+            ],
+        ]);
 
-        if (!in_array($subscription->status, ['incomplete', 'incomplete_expired', 'canceled'])) {
-            $datum = new \stdClass();
-            $datum->userid = $USER->id;
-            $datum->subscriptionid = $subscription->id;
-            $datum->customerid = $customer->id;
-            $datum->status = $subscription->status;
-            $datum->productid = $subscription->items->first()->price->product;
-            $datum->priceid = $subscription->items->first()->price->id;
+        return $session->id;
+    }
 
-            $DB->insert_record('paygw_stripe_subscriptions', $datum);
-
-            $paymentid = helper::save_payment($payable->get_account_id(), $component, $paymentarea,
-                $itemid, $USER->id, $cost, $payable->get_currency(), 'stripe');
-            helper::deliver_order($component, $paymentarea, $itemid, $paymentid, $USER->id);
-
-            // Find redirection.
-            $url = helper::get_success_url($component, $paymentarea, $itemid);
-            redirect($url, get_string('subscriptionsuccessful', 'paygw_stripe'), 0, 'success');
-        } else {
-            redirect(new moodle_url('/'), get_string('subscriptionerror', 'paygw_stripe'));
-        }
-
-        return null;
+    /**
+     * Retrieve the Checkout Session mode
+     *
+     * @param string $sessionid Stripe session ID
+     * @return string
+     * @throws ApiErrorException
+     */
+    public function get_sessionmode(string $sessionid): string {
+        $session = $this->stripe->checkout->sessions->retrieve($sessionid);
+        return $session->mode;
     }
 
     /**
@@ -525,6 +481,19 @@ class stripe_helper {
         // Check payment intent here as the session status is a simple pass/fail that doesn't include processing.
         $session = $this->stripe->checkout->sessions->retrieve($sessionid, ['expand' => ['payment_intent']]);
         return $session->payment_intent->status === 'processing';
+    }
+
+    /**
+     * Check the status of a Stripe subscription
+     *
+     * @param string $sessionid Stripe session ID
+     * @return string
+     * @throws ApiErrorException
+     */
+    public function get_subscription_status(string $sessionid): string {
+        $session = $this->stripe->checkout->sessions->retrieve($sessionid);
+        $subscription = $this->stripe->subscriptions->retrieve($session->subscription);
+        return $subscription->status;
     }
 
     /**
@@ -644,7 +613,7 @@ class stripe_helper {
      * @param int $userid
      * @return void
      */
-    public function deliver_course(string $component, string $paymentarea,int $itemid, int $userid) {
+    public function deliver_course(string $component, string $paymentarea, int $itemid, int $userid) {
         $payable = helper::get_payable($component, $paymentarea, $itemid);
         $cost = helper::get_rounded_cost($payable->get_amount(), $payable->get_currency(), helper::get_gateway_surcharge('stripe'));
         $paymentid = helper::save_payment($payable->get_account_id(), $component, $paymentarea,
@@ -737,11 +706,6 @@ class stripe_helper {
                     return false;
                 }
                 $this->save_payment_status($session->id); // Update saved intent status.
-                if (!$this->is_paid($session->id)) {
-                    // Payment not complete, notify user payment failed.
-                    $this->notify_user($intentrecord->userid, 'failed');
-                    break;
-                }
 
                 // Deliver course.
                 $this->deliver_course($metadata['component'], $metadata['paymentarea'], $metadata['itemid'], $intentrecord->userid);
@@ -963,55 +927,36 @@ class stripe_helper {
      * Retrieve start and end dates for anchored billing, based on config subscription settings.
      *
      * @param \stdClass $config
-     * @return array
+     * @return DateTime
      * @throws \Exception
      */
-    private function get_anchor_billing_dates($config): array {
+    private function get_anchor_billing_dates($config): DateTime {
+        // Identify first day of the week for weekly intervals.
+        $days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
+        $calendar = \core_calendar\type_factory::get_calendar_instance();
+        $firstdayofweek = $days[$calendar->get_starting_weekday()];
+
         $dates = [
-            'daily' => [
-                new DateTime('this day 00:00:00', new DateTimeZone('UTC')),
-                new DateTime('next day 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'weekly' => [
-                new DateTime('first day of this week 00:00:00', new DateTimeZone('UTC')),
-                new DateTime('first day of next week 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'monthly' => [
-                new DateTime('first day of this month 00:00:00', new DateTimeZone('UTC')),
-                new DateTime('first day of next month 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'every3months' => [
-                new DateTime('first day of this month 00:00:00', new DateTimeZone('UTC')),
-                (new DateTime('first day of this month 00:00:00',
-                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('3 months'))
-            ],
-            'every6months' => [
-                new DateTime('first day of this month 00:00:00', new DateTimeZone('UTC')),
-                (new DateTime('first day of this month 00:00:00',
-                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('6 months'))
-            ],
-            'yearly' => [
-                new DateTime('first day of this year 00:00:00', new DateTimeZone('UTC')),
-                new DateTime('first day of next year 00:00:00', new DateTimeZone('UTC'))
-            ]
+            'daily' => new DateTime('next day 00:00:00', new DateTimeZone('UTC')),
+            'weekly' => new DateTime('this ' . $firstdayofweek . ' 00:00:00', new DateTimeZone('UTC')),
+            'monthly' => new DateTime('first day of next month 00:00:00', new DateTimeZone('UTC')),
+            'every3months' => (new DateTime('first day of this month 00:00:00',
+                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('3 months')),
+            'every6months' => (new DateTime('first day of this month 00:00:00',
+                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('6 months')),
+            'yearly' => new DateTime('first day of this year 00:00:00', new DateTimeZone('UTC')),
         ];
         if ($config->subscriptioninterval !== 'custom') {
             return $dates[$config->subscriptioninterval];
         }
         if ($config->customsubscriptioninterval === 'day') {
-            return [
-                new DateTime('this day 00:00:00', new DateTimeZone('UTC')),
-                (new DateTime('this day 00:00:00',
+            return (new DateTime('this day 00:00:00',
                     new DateTimeZone('UTC')))->add(DateInterval::createFromDateString($config->customsubscriptionintervalcount .
-                    ' days'))
-            ];
+                    ' days'));
         } else {
-            return [
-                new DateTime('first day of this ' . $config->customsubscriptioninterval . ' 00:00:00', new DateTimeZone('UTC')),
-                (new DateTime('first day of this ' . $config->customsubscriptioninterval . ' 00:00:00',
+            return (new DateTime('first day of this ' . $config->customsubscriptioninterval . ' 00:00:00',
                     new DateTimeZone('UTC')))->add(DateInterval::createFromDateString($config->customsubscriptionintervalcount .
-                    ' ' . $config->customsubscriptioninterval . 's'))
-            ];
+                    ' ' . $config->customsubscriptioninterval . 's'));
         }
     }
 
@@ -1023,31 +968,15 @@ class stripe_helper {
      * @throws \Exception
      */
     private function get_trial_end_date($config): DateTime {
-        if ($config->firstintervalfree) {
-            list ($date, $nextdate) = $this->get_anchor_billing_dates($config);
-            return $nextdate;
-        }
         $dates = [
-            'daily' => [
-                new DateTime('next day 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'weekly' => [
-                new DateTime('this day next week 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'monthly' => [
-                new DateTime('this day next month 00:00:00', new DateTimeZone('UTC')),
-            ],
-            'every3months' => [
-                (new DateTime('this day next month 00:00:00',
-                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('3 months'))
-            ],
-            'every6months' => [
-                (new DateTime('this day next month 00:00:00',
-                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('6 months'))
-            ],
-            'yearly' => [
-                new DateTime('this day next year 00:00:00', new DateTimeZone('UTC'))
-            ]
+            'daily' => new DateTime('next day 00:00:00', new DateTimeZone('UTC')),
+            'weekly' => new DateTime('this day next week 00:00:00', new DateTimeZone('UTC')),
+            'monthly' => new DateTime('this day next month 00:00:00', new DateTimeZone('UTC')),
+            'every3months' => (new DateTime('this day next month 00:00:00',
+                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('3 months')),
+            'every6months' => (new DateTime('this day next month 00:00:00',
+                    new DateTimeZone('UTC')))->add(DateInterval::createFromDateString('6 months')),
+            'yearly' => new DateTime('this day next year 00:00:00', new DateTimeZone('UTC'))
         ];
         if ($config->subscriptioninterval !== 'custom') {
             return $dates[$config->subscriptioninterval];
@@ -1056,5 +985,4 @@ class stripe_helper {
             new DateTimeZone('UTC')))->add(DateInterval::createFromDateString($config->customsubscriptionintervalcount .
             ' ' . $config->customsubscriptioninterval . 's'));
     }
-
 }

--- a/classes/stripe_helper.php
+++ b/classes/stripe_helper.php
@@ -636,6 +636,23 @@ class stripe_helper {
     }
 
     /**
+     * Deliver course
+     *
+     * @param string $component
+     * @param string $paymentarea
+     * @param int $itemid
+     * @param int $userid
+     * @return void
+     */
+    public function deliver_course(string $component, string $paymentarea,int $itemid, int $userid) {
+        $payable = helper::get_payable($component, $paymentarea, $itemid);
+        $cost = helper::get_rounded_cost($payable->get_amount(), $payable->get_currency(), helper::get_gateway_surcharge('stripe'));
+        $paymentid = helper::save_payment($payable->get_account_id(), $component, $paymentarea,
+            $itemid, $userid, $cost, $payable->get_currency(), 'stripe');
+        helper::deliver_order($component, $paymentarea, $itemid, $paymentid, $userid);
+    }
+
+    /**
      * Find and return webhook endpoint if it exists.
      * Retrieve secret from Moodle database and add to webhook object.
      *
@@ -727,13 +744,7 @@ class stripe_helper {
                 }
 
                 // Deliver course.
-                $payable = helper::get_payable($metadata['component'], $metadata['paymentarea'], $metadata['itemid']);
-                $cost = helper::get_rounded_cost($payable->get_amount(), $payable->get_currency(),
-                    helper::get_gateway_surcharge('stripe'));
-                $paymentid = helper::save_payment($payable->get_account_id(), $metadata['component'], $metadata['paymentarea'],
-                    $metadata['itemid'], $intentrecord->userid, $cost, $payable->get_currency(), 'stripe');
-                helper::deliver_order($metadata['component'], $metadata['paymentarea'], $metadata['itemid'], $paymentid,
-                    $intentrecord->userid);
+                $this->deliver_course($metadata['component'], $metadata['paymentarea'], $metadata['itemid'], $intentrecord->userid);
 
                 // Notify user payment was successful.
                 $url = helper::get_success_url($metadata['component'], $metadata['paymentarea'], $metadata['itemid']);

--- a/db/messages.php
+++ b/db/messages.php
@@ -27,14 +27,14 @@ defined('MOODLE_INTERNAL') || die();
 $messageproviders = [
     'payment_successful' => [
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         ],
     ],
     'payment_failed' => [
         'defaults' => [
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         ],
     ],
 ];

--- a/lang/en/paygw_stripe.php
+++ b/lang/en/paygw_stripe.php
@@ -45,7 +45,7 @@ $string['defaulttaxbehavior_help'] = 'Default behavior of tax (inclusive, exclus
 $string['profilecat'] = 'Stripe Payment Subscriptions';
 $string['cancelsubscriptions'] = 'Change Subscriptions';
 $string['subscriptions'] = 'Subscriptions';
-$string['subscriptionsuccessful'] = 'Successfully subscribed';
+$string['subscriptionsuccessful'] = 'Successfully subscribed. You can manage your Stripe Payment subscriptions from your profile page.';
 $string['paymenttype'] = 'Payment Type';
 $string['paymenttype:onetime'] = 'One Time';
 $string['paymenttype:subscription'] = 'Subscription';
@@ -53,11 +53,12 @@ $string['subscriptioninterval'] = 'Subscription Period';
 $string['customsubscriptioninterval'] = 'Custom Subscription Period';
 $string['customsubscriptionintervalcount'] = 'Custom Subscription Period Interval';
 $string['customsubscriptionintervalcount_help'] = '';
-$string['anchoredbilling'] = 'Use the start of the current interval as a fixed billing date';
+$string['anchoredbilling'] = 'Use the start of the subscription interval as a fixed billing date.';
 $string['anchoredbilling_help'] =
-    'E.g. You subscribe in the middle of the month, you will be billed immediately for the current month';
+    'E.g. For a monthly subscription, billing will be done every 1st of the month. If a user subscribes in the middle of the month, they will be charged a prorated amount covering from the registration day to the end of the month';
 $string['trialperiod'] = 'Trial Period';
-$string['trialperiod_help'] = 'E.g. You register on the 25th of April, April is free and billing starts on the 1st May';
+$string['trialperiod_help'] = 'E.g. the first interval is free. If the subscription is created on the 24th April, a month is free and billing starts on the 24th May.<br/>
+    If billing happens at the start of the interval (e.g. on the 1st of the month), the pro-rated amount is waved. If a user registers on the 24th April, April is free and billing starts on the 1st May';
 $string['failedtosetdefaultpaymentmethod'] = 'Failed to set up a payment method for subscription, please try again.';
 $string['subscriptionerror'] = 'There was an error creating the subscription, please contact the site administrator for help';
 $string['cancelsubscription'] = 'Cancel subscription';

--- a/process.php
+++ b/process.php
@@ -41,14 +41,28 @@ $config = (object) helper::get_gateway_configuration($component, $paymentarea, $
 $stripehelper = new stripe_helper($config->apikey, $config->secretkey);
 
 $stripehelper->save_payment_status($sessionid);
-if ($stripehelper->is_paid($sessionid)) {
-    // Deliver course.
-    $stripehelper->deliver_course($component, $paymentarea, $itemid, $USER->id);
 
-    // Find redirection.
-    $url = helper::get_success_url($component, $paymentarea, $itemid);
-    redirect($url, get_string('paymentsuccessful', 'paygw_stripe'), 0, 'success');
-} else if ($stripehelper->is_pending($sessionid)) {
-    redirect(new moodle_url('/'), get_string('paymentpending', 'paygw_stripe'));
+$sessionmode = $stripehelper->get_sessionmode($sessionid);
+
+if ($sessionmode === 'subscription') {
+    $subscriptionstatus = $stripehelper->get_subscription_status($sessionid);
+    if (!in_array($subscriptionstatus, ['incomplete', 'incomplete_expired', 'canceled'])) {
+        $stripehelper->deliver_course($component, $paymentarea, $itemid, $USER->id);
+
+        // Find redirection.
+        $url = helper::get_success_url($component, $paymentarea, $itemid);
+        redirect($url, get_string('subscriptionsuccessful', 'paygw_stripe'), 0, 'success');
+    } else {
+        redirect(new moodle_url('/'), get_string('subscriptionerror', 'paygw_stripe'));
+    }
+} else if ($sessionmode === 'payment') {
+    if ($stripehelper->is_paid($sessionid)) {
+        $stripehelper->deliver_course($component, $paymentarea, $itemid, $USER->id);
+
+        // Find redirection.
+        $url = helper::get_success_url($component, $paymentarea, $itemid);
+        redirect($url, get_string('paymentsuccessful', 'paygw_stripe'), 0, 'success');
+    } else if ($stripehelper->is_pending($sessionid)) {
+        redirect(new moodle_url('/'), get_string('paymentpending', 'paygw_stripe'));
+    }
 }
-redirect(new moodle_url('/'), get_string('paymentcancelled', 'paygw_stripe'));

--- a/process.php
+++ b/process.php
@@ -43,11 +43,7 @@ $stripehelper = new stripe_helper($config->apikey, $config->secretkey);
 $stripehelper->save_payment_status($sessionid);
 if ($stripehelper->is_paid($sessionid)) {
     // Deliver course.
-    $payable = helper::get_payable($component, $paymentarea, $itemid);
-    $cost = helper::get_rounded_cost($payable->get_amount(), $payable->get_currency(), helper::get_gateway_surcharge('stripe'));
-    $paymentid = helper::save_payment($payable->get_account_id(), $component, $paymentarea,
-        $itemid, $USER->id, $cost, $payable->get_currency(), 'stripe');
-    helper::deliver_order($component, $paymentarea, $itemid, $paymentid, $USER->id);
+    $stripehelper->deliver_course($component, $paymentarea, $itemid, $USER->id);
 
     // Find redirection.
     $url = helper::get_success_url($component, $paymentarea, $itemid);


### PR DESCRIPTION
This PR changes the way subscription are implemented to use Stripe Checkout Sessions in subscription mode.

The changes made are:

- stripe_helper.php
	- Updated
		- generate_subscription function to use Checkout Session in subscription mode. This includes changing the success url to use process.php to process the new subscription.
		- get_anchor_billing_dates to remove backdating logic, return billing start date only, and fix failing first day next week
		- get_trial_end_date to remove logic related to anchor billing and fix the returned values
	- Added functions
		- get_sessionmode
		- get_subscription_status
		- deliver_course
	- Removed failed payment logic from process_stripe_event when case =  'checkout.session.async_payment_succeeded'

- lang file
	- Updated strings to be more explicit

- pay.php
	- Remove logic used in previous subscription implementation

- process.php
	- Added logic to handle Sessions in subscription mode
	- Removed paymentcancelled redirect as there is a defined cancelurl redirecting to cancelled.php in the Session call

I didn't modified the way anchor is calculated so for a 3 months period subscription, the prorated period will be the remainder of the first month plus two months (for example). For the trail period without billing anchor, the fee waved is the totality of the first interval. Let me know if you would like to revisit those.

I also cleaned up deprecated constants in db/messages.php.