### PR TITLE
ISSUE-49: Only create old stripe helper if existing keys exist

### DIFF
--- a/classes/gateway.php
+++ b/classes/gateway.php
@@ -225,8 +225,10 @@ class gateway extends \core_payment\gateway {
 
             $DB->delete_records('paygw_stripe_webhooks', ['paymentaccountid' => $paymentaccountid]);
             try {
-                $oldhelper = new stripe_helper($existingdata['apikey'], $existingdata['secretkey']);
-                $oldhelper->delete_webhook($paymentaccountid);
+                if (is_string($existingdata['apikey']) && is_string($existingdata['secretkey'])) {
+                    $oldhelper = new stripe_helper($existingdata['apikey'], $existingdata['secretkey']);
+                    $oldhelper->delete_webhook($paymentaccountid);
+                }
 
                 $newhelper = new stripe_helper($data->apikey, $data->secretkey);
                 $newhelper->create_webhook($paymentaccountid);


### PR DESCRIPTION
## Issue
#49 

## Summary
Currently the initial installation of this plugin is blocked by a null API key error on new Moodle 5.0 installations. This is because validations in the `gateway.php` file attempt to make the old stripe helper with existing keys, which do not exist in new installs.

Moodle 5.0 recently upgraded to require PHP `8.2.0`, so this error might have come about due to the PHP upgrade.

The fix is to add a string check to the existing API keys, and possibly to remove that hack if there is a way around it now.

## Testing
I tested manually through zipping my changes and uploading them and was able to add new API keys when none existed beforehand.
