### PR TITLE
Fix undefined gateway configuration property error.

### DIFF
--- a/classes/stripe_helper.php
+++ b/classes/stripe_helper.php
@@ -384,9 +384,9 @@ class stripe_helper {
             'automatic_tax' => [
                 'enabled' => $config->enableautomatictax == 1,
             ],
-            'billing_address_collection' => $config->collectbillingaddress == 1 ? 'required' : 'auto',
+            'billing_address_collection' => ($config->collectbillingaddress ?? 0) == 1 ? 'required' : 'auto',
             'invoice_creation' => [
-                'enabled' => $config->invoicecreation == 1,
+                'enabled' => ($config->invoicecreation ?? 0) == 1,
                 'invoice_data' => [
                     'issuer' => [
                         'type' => 'self',


### PR DESCRIPTION
Fixes the following error found in the PHP logs when a user submits a payment:

```log
PHP Warning:  Undefined property: stdClass::$collectbillingaddress in moodle/web/payment/gateway/stripe/classes/stripe_helper.php on line 387
PHP Warning:  Undefined property: stdClass::$invoicecreation in moodle/web/payment/gateway/stripe/classes/stripe_helper.php on line 389
```