### PR TITLE
Remove unsupported UPI payment method from Stripe gateway

### DIFF
--- a/classes/gateway.php
+++ b/classes/gateway.php
@@ -96,7 +96,6 @@ class gateway extends \core_payment\gateway {
             'ideal' => get_string('paymentmethod:ideal', 'paygw_stripe'),
             'p24' => get_string('paymentmethod:p24', 'paygw_stripe'),
             'sepa_debit' => get_string('paymentmethod:sepa_debit', 'paygw_stripe'),
-            'upi' => get_string('paymentmethod:upi', 'paygw_stripe'),
             'wechat_pay' => get_string('paymentmethod:wechat_pay', 'paygw_stripe'),
             'klarna' => get_string('paymentmethod:klarna', 'paygw_stripe'),
             'nz_bank_account' => get_string('paymentmethod:nz_bank_account', 'paygw_stripe'),

--- a/lang/en/paygw_stripe.php
+++ b/lang/en/paygw_stripe.php
@@ -76,7 +76,6 @@ $string['paymentmethod:nz_bank_account'] = 'NZ BECS Direct Debit';
 $string['paymentmethod:p24'] = 'P24';
 $string['paymentmethod:sepa_debit'] = 'SEPA Direct Debit';
 $string['paymentmethod:twint'] = 'TWINT';
-$string['paymentmethod:upi'] = 'UPI';
 $string['paymentmethod:wechat_pay'] = 'WeChat Pay';
 
 $string['paymentmethods'] = 'Payment Methods';


### PR DESCRIPTION
UPI is not supported by Stripe's payment_method_types parameter. Stripe removed support for UPI from PaymentMethodConfiguration in their API.

- Remove UPI from payment methods configuration in gateway.php
- Remove UPI language string from language file