### PR TITLE
Cap Stripe Checkout Session expires_at to 24 hours

### DIFF
--- a/classes/stripe_helper.php
+++ b/classes/stripe_helper.php
@@ -508,7 +508,7 @@ class stripe_helper {
             'customer_update' => [
                 'address' => 'auto',
             ],
-            'expires_at' => time() + $CFG->sessiontimeout,
+            'expires_at' => time() + min($CFG->sessiontimeout, 24 * 60 * 60),
         ]);
 
         return $session->id;
@@ -618,7 +618,7 @@ class stripe_helper {
             'customer_update' => [
                 'address' => 'auto',
             ],
-            'expires_at' => time() + $CFG->sessiontimeout,
+            'expires_at' => time() + min($CFG->sessiontimeout, 24 * 60 * 60),
         ]);
 
         return $session->id;


### PR DESCRIPTION
Stripe enforces a hard upper limit of 86,400 seconds (24 hours) on the expires_at parameter when creating a Checkout Session. If a Moodle site's session timeout $CFG->sessiontimeout is configured to 24 hours or longer, the plugin passes a value equal to or greater than Stripe's limit, causing every checkout attempt to fail with:

> The expires_at timestamp must be less than 24 hours from Checkout Session creation.

In classes/stripe_helper.php, the expires_at value was set directly from $CFG->sessiontimeout with no upper bound. Moodle's default session timeout is 2 hours, so most installations are unaffected. However, sites that extend their session timeout to 24 hours or more will hit Stripe's limit on every payment attempt.                                                                                                                                            
                                                                                                                                                                                                                                                                                                  
This change caps the expires_at value using min() so it never exceeds 24 hours. Sites with a session timeout shorter than 24 hours are unaffected, while sites with longer timeouts will now have their checkout sessions expire after 24 hours matching Stripe's maximum rather than failing entirely.